### PR TITLE
Makes the tag scanner more flexible for tag description

### DIFF
--- a/src/main/java/com/accelad/docx4j/tags/TagScanner.java
+++ b/src/main/java/com/accelad/docx4j/tags/TagScanner.java
@@ -16,7 +16,15 @@ public class TagScanner {
     private static final String TAG_END = "}";
 
     private static final String REGEX = "(\\$\\{[^}]*\\})";
-    private static final Pattern PATTERN = Pattern.compile(REGEX);
+    private final Pattern PATTERN;
+
+    public TagScanner() {
+        PATTERN = Pattern.compile(REGEX);
+    }
+
+    public TagScanner(String regex) {
+        PATTERN = Pattern.compile(regex);
+    }
 
     public Tags scan(Paragraphs paragraphs) {
         Tags tags = new Tags();

--- a/src/test/java/com/accelad/docx4j/tags/TagScannerTest.java
+++ b/src/test/java/com/accelad/docx4j/tags/TagScannerTest.java
@@ -72,6 +72,18 @@ public class TagScannerTest {
     }
 
     @Test
+    public void should_recognize_a_different_tag_format_when_a_different_regex_is_given() {
+        Paragraphs paragraphs = new Paragraphs();
+        when(aParagraph.asString()).thenReturn("%[" + TAG_NAME + "]");
+        paragraphs.add(aParagraph);
+
+        Tags tags = new TagScanner("((\\%\\[[^\\]]*\\]))").scan(paragraphs);
+
+        Tag tag = tags.iterator().next();
+        assertThat(tag.getTagName().asString(), is(TAG_NAME));
+    }
+
+    @Test
     public void should_create_tag_with_correct_tag_name_when_a_paragraph_contains_a_tag_name_with_dot() {
         Paragraphs paragraphs = new Paragraphs();
         when(aParagraph.asString()).thenReturn("${" + TAG_NAME_WITH_DOT + "}");


### PR DESCRIPTION
The goal for this commit is to configure the tag name grammar.
We will be able to change the regular expression in the application and
thus we are not limited to the library.