### PR TITLE
Fix a bug in the Tag scanner when a tag is divided in two

### DIFF
--- a/src/main/java/com/accelad/docx4j/tags/TagScanner.java
+++ b/src/main/java/com/accelad/docx4j/tags/TagScanner.java
@@ -63,13 +63,13 @@ public class TagScanner {
             if (match.matches()) {
                 items.put(item, position);
             } else {
-                if (txt.equals(TAG_START)) {
+                if (txt.startsWith(TAG_START)) {
                     started = true;
                 }
                 if (started) {
                     items.put(item, position);
                 }
-                if (started && txt.equals(TAG_END)) {
+                if (started && txt.endsWith(TAG_END)) {
                     started = false;
                 }
             }

--- a/src/main/java/com/accelad/docx4j/tags/Tags.java
+++ b/src/main/java/com/accelad/docx4j/tags/Tags.java
@@ -29,4 +29,11 @@ public class Tags implements Iterable<Tag> {
         return list.iterator();
     }
 
+    public boolean contains(Tag tag) {
+        return list.contains(tag);
+    }
+
+    public boolean isEmpty() {
+        return list.isEmpty();
+    }
 }

--- a/src/test/java/com/accelad/docx4j/tags/TagScannerTest.java
+++ b/src/test/java/com/accelad/docx4j/tags/TagScannerTest.java
@@ -1,80 +1,48 @@
 package com.accelad.docx4j.tags;
 
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
-
-import java.util.Iterator;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
+import com.accelad.docx4j.facade.*;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 
-import com.accelad.docx4j.facade.ListWordItems;
-import com.accelad.docx4j.facade.Paragraph;
-import com.accelad.docx4j.facade.Paragraphs;
-import com.accelad.docx4j.facade.Run;
-import com.accelad.docx4j.facade.Text;
-import com.accelad.docx4j.facade.WordItem;
-import com.accelad.docx4j.facade.WordItems;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class TagScannerTest {
 
     private static final String TAG_NAME = "tagName";
-    private static final String A_PARAGRAPH_WITH_TAG_NAME = "A paragraph ${" + TAG_NAME + "} tagged";
     private static final String TAG_NAME_WITH_DOT = "tag.name";
     private static final String TAG_NAME_WITH_PARENTHESIS = "tagnamewithparenthesis()";
     private static final String TAG_NAME_WITH_QUOTES = "tagname\"double\"and\'simple\'";
     private static final String TAG_NAME_WITH_NUMBER = "tagNameWithNumber0123456789";
-
-    @Mock private Paragraph aParagraph;
+    private static final String TAG_START = "${";
+    private static final String TAG_END = "}";
 
     private TagScanner tagScanner;
 
     @Before
     public void initialize() {
         tagScanner = new TagScanner();
-
-        initMocks(this);
-        ListWordItems listWordItems = new ListWordItems();
-        when(aParagraph.getContent()).thenReturn(listWordItems);
-    }
-
-    @Test
-    public void should_create_tag_with_correct_tag_name_when_a_paragraph_contains_a_tag_name() {
-        Paragraphs paragraphs = new Paragraphs();
-        when(aParagraph.asString()).thenReturn(A_PARAGRAPH_WITH_TAG_NAME);
-        paragraphs.add(aParagraph);
-
-        Tags tags = tagScanner.scan(paragraphs);
-
-        Tag tag = tags.iterator().next();
-        assertThat(tag.getTagName().asString(), is(TAG_NAME));
     }
 
     @Test
     public void should_create_tag_with_correct_tag_name_when_a_paragraph_contains_only_a_tag_name() {
         Paragraphs paragraphs = new Paragraphs();
-        when(aParagraph.asString()).thenReturn("${" + TAG_NAME + "}");
+        Paragraph aParagraph = createParagraphWithTag(TAG_START + TAG_NAME + TAG_END);
         paragraphs.add(aParagraph);
 
         Tags tags = tagScanner.scan(paragraphs);
 
-        Tag tag = tags.iterator().next();
-        assertThat(tag.getTagName().asString(), is(TAG_NAME));
+        IndexedWordItems wordItemsList = new IndexedWordItems();
+        Tag expectedTag = new Tag(new TagName(TAG_NAME), aParagraph, wordItemsList);
+        assertThat(tags.contains(expectedTag), equalTo(true));
     }
 
     @Test
     public void should_recognize_a_different_tag_format_when_a_different_regex_is_given() {
         Paragraphs paragraphs = new Paragraphs();
-        when(aParagraph.asString()).thenReturn("%[" + TAG_NAME + "]");
+        Paragraph aParagraph = createParagraphWithTag("%[" + TAG_NAME + "]");
         paragraphs.add(aParagraph);
 
         Tags tags = new TagScanner("((\\%\\[[^\\]]*\\]))").scan(paragraphs);
@@ -86,121 +54,148 @@ public class TagScannerTest {
     @Test
     public void should_create_tag_with_correct_tag_name_when_a_paragraph_contains_a_tag_name_with_dot() {
         Paragraphs paragraphs = new Paragraphs();
-        when(aParagraph.asString()).thenReturn("${" + TAG_NAME_WITH_DOT + "}");
+        Paragraph aParagraph = createParagraphWithTag(TAG_START + TAG_NAME_WITH_DOT + TAG_END);
         paragraphs.add(aParagraph);
 
         Tags tags = tagScanner.scan(paragraphs);
 
-        Tag tag = tags.iterator().next();
-        assertThat(tag.getTagName().asString(), is(TAG_NAME_WITH_DOT));
+        IndexedWordItems wordItemsList = new IndexedWordItems();
+        Tag expectedTag = new Tag(new TagName(TAG_NAME_WITH_DOT), aParagraph, wordItemsList);
+        assertThat(tags.contains(expectedTag), equalTo(true));
     }
-
 
     @Test
     public void should_create_tag_with_correct_tag_name_when_a_paragraph_contains_a_tag_name_with_number() {
         Paragraphs paragraphs = new Paragraphs();
-        when(aParagraph.asString()).thenReturn("${" + TAG_NAME_WITH_NUMBER + "}");
+        Paragraph aParagraph = createParagraphWithTag(TAG_START + TAG_NAME_WITH_NUMBER + TAG_END);
         paragraphs.add(aParagraph);
 
         Tags tags = tagScanner.scan(paragraphs);
 
-        Tag tag = tags.iterator().next();
-        assertThat(tag.getTagName().asString(), is(TAG_NAME_WITH_NUMBER));
+        IndexedWordItems wordItemsList = new IndexedWordItems();
+        Tag expectedTag = new Tag(new TagName(TAG_NAME_WITH_NUMBER), aParagraph, wordItemsList);
+        assertThat(tags.contains(expectedTag), equalTo(true));
     }
 
     @Test
     public void should_create_tag_with_correct_tag_name_when_a_paragraph_contains_a_tag_name_with_parenthesis() {
         Paragraphs paragraphs = new Paragraphs();
-        when(aParagraph.asString()).thenReturn("${" + TAG_NAME_WITH_PARENTHESIS + "}");
+        Paragraph aParagraph = createParagraphWithTag(TAG_START + TAG_NAME_WITH_PARENTHESIS + TAG_END);
         paragraphs.add(aParagraph);
 
         Tags tags = tagScanner.scan(paragraphs);
 
-        Tag tag = tags.iterator().next();
-        assertThat(tag.getTagName().asString(), is(TAG_NAME_WITH_PARENTHESIS));
+        IndexedWordItems wordItemsList = new IndexedWordItems();
+        Tag expectedTag = new Tag(new TagName(TAG_NAME_WITH_PARENTHESIS), aParagraph, wordItemsList);
+        assertThat(tags.contains(expectedTag), equalTo(true));
     }
 
     @Test
     public void should_create_tag_with_correct_tag_name_when_a_paragraph_contains_a_tag_name_with_quote() {
         Paragraphs paragraphs = new Paragraphs();
-        when(aParagraph.asString()).thenReturn("${" + TAG_NAME_WITH_QUOTES + "}");
+        Paragraph aParagraph = createParagraphWithTag(TAG_START + TAG_NAME_WITH_QUOTES + TAG_END);
         paragraphs.add(aParagraph);
 
         Tags tags = tagScanner.scan(paragraphs);
 
-        Tag tag = tags.iterator().next();
-        assertThat(tag.getTagName().asString(), is(TAG_NAME_WITH_QUOTES));
+        IndexedWordItems wordItemsList = new IndexedWordItems();
+        Tag expectedTag = new Tag(new TagName(TAG_NAME_WITH_QUOTES), aParagraph, wordItemsList);
+
+        assertThat(tags.contains(expectedTag), equalTo(true));
     }
 
     @Test
     public void should_return_empty_tags_when_no_paragraph_contains_tag_identifier() {
         Paragraphs paragraphs = new Paragraphs();
-        when(aParagraph.asString()).thenReturn("No tag in paragraph");
+        Paragraph aParagraph = new Paragraph();
         paragraphs.add(aParagraph);
 
         Tags tags = tagScanner.scan(paragraphs);
 
-        assertFalse(tags.iterator().hasNext());
+        assertTrue(tags.isEmpty());
     }
 
     @Test
     public void should_create_tag_with_one_word_item_when_tag_identifier_is_a_word_item() {
         Paragraphs paragraphs = new Paragraphs();
-        when(aParagraph.asString()).thenReturn(A_PARAGRAPH_WITH_TAG_NAME);
+        Paragraph aParagraph = new Paragraph();
         paragraphs.add(aParagraph);
-        ListWordItems wordItems = new ListWordItems();
-        Run wordItem1 = new Run();
-        wordItem1.addText(new Text("A paragraph "));
-        Run expectedItem = new Run();
-        expectedItem.addText(new Text("${" + TAG_NAME + "}"));
-        Run wordItem3 = new Run();
-        wordItem3.addText(new Text(" tagged"));
-        wordItems.add(wordItem1);
-        wordItems.add(expectedItem);
-        wordItems.add(wordItem3);
-        when(aParagraph.getContent()).thenReturn(wordItems);
+        Run beginOfTheParagraphText = createText("A paragraph ");
+        Run expectedItem = createText(TAG_START + TAG_NAME + TAG_END);
+        Run endOfParagraphText = createText(" tagged");
+        aParagraph.addItem(beginOfTheParagraphText);
+        aParagraph.addItem(expectedItem);
+        aParagraph.addItem(endOfParagraphText);
 
         Tags tags = tagScanner.scan(paragraphs);
 
-        Tag tag = tags.iterator().next();
-        WordItems items = tag.getItems();
-        Iterator<WordItem> iterator = items.iterator();
-        assertThat(iterator.next(), is(expectedItem));
-        assertFalse(iterator.hasNext());
+        IndexedWordItems wordItemsList = new IndexedWordItems();
+        Tag expectedTag = new Tag(new TagName(TAG_NAME), aParagraph, wordItemsList);
+
+        assertThat(tags.contains(expectedTag), equalTo(true));
     }
 
     @Test
-    public void should_create_tag_with_word_items_when_tag_identifier_is_composed_by_multiple_word_item() {
+    public void should_create_tag_with_word_items_when_tag_identifier_is_composed_by_multiple_word_item_in_middle_of_paragraph() {
         Paragraphs paragraphs = new Paragraphs();
-        when(aParagraph.asString()).thenReturn(A_PARAGRAPH_WITH_TAG_NAME);
+        Paragraph aParagraph = new Paragraph();
         paragraphs.add(aParagraph);
-        ListWordItems wordItems = new ListWordItems();
-        Run wordItem1 = new Run();
-        wordItem1.addText(new Text("A paragraph "));
-        Run wordItem2 = new Run();
-        wordItem2.addText(new Text("${"));
-        Run wordItem3 = new Run();
-        wordItem3.addText(new Text(TAG_NAME));
-        Run wordItem4 = new Run();
-        wordItem4.addText(new Text("}"));
-        Run wordItem5 = new Run();
-        wordItem5.addText(new Text(" tagged"));
-        wordItems.add(wordItem1);
-        wordItems.add(wordItem2);
-        wordItems.add(wordItem3);
-        wordItems.add(wordItem4);
-        wordItems.add(wordItem5);
-        when(aParagraph.getContent()).thenReturn(wordItems);
+        Run beginOfTheParagraphText = createText("A paragraph ");
+        Run tagStartText = createText(TAG_START);
+        Run tagNameText = createText(TAG_NAME);
+        Run tagEndText = createText(TAG_END);
+        Run endOfParagraphText = createText(" tagged");
+        aParagraph.addItem(beginOfTheParagraphText);
+        aParagraph.addItem(tagStartText);
+        aParagraph.addItem(tagNameText);
+        aParagraph.addItem(tagEndText);
+        aParagraph.addItem(endOfParagraphText);
 
         Tags tags = tagScanner.scan(paragraphs);
 
-        Tag tag = tags.iterator().next();
-        List<WordItem> wordItemsActual = getWordItems(tag.getItems());
-        assertThat(wordItemsActual, hasSize(3));
-        assertThat(wordItemsActual, hasItems(wordItem2, wordItem3, wordItem4));
+        IndexedWordItems wordItemsList = new IndexedWordItems();
+        Tag expectedTag = new Tag(new TagName(TAG_NAME), aParagraph, wordItemsList);
+
+        assertThat(tags.contains(expectedTag), equalTo(true));
     }
 
-    private List<WordItem> getWordItems(WordItems items) {
-        return StreamSupport.stream(items.spliterator(), false).collect(Collectors.toList());
+    @Test
+    public void should_create_tag_when_tag_identifier_is_divided_in_two_parts() {
+        String firstPartNameAsString = "FIRST PART";
+        String secondPartNameAsString = "SECOND PART";
+
+        Paragraphs paragraphs = new Paragraphs();
+        Paragraph aParagraph = new Paragraph();
+        paragraphs.add(aParagraph);
+        Run beginOfParagraphText = createText("A paragraph ");
+        Run firstPartOfTag = createText(TAG_START + firstPartNameAsString);
+        Run secondPartOfTag = createText(secondPartNameAsString + TAG_END);
+        Run endOfParagraphText = createText(" tagged");
+        aParagraph.addItem(beginOfParagraphText);
+        aParagraph.addItem(firstPartOfTag);
+        aParagraph.addItem(secondPartOfTag);
+        aParagraph.addItem(endOfParagraphText);
+
+        Tags tags = tagScanner.scan(paragraphs);
+
+        IndexedWordItems wordItemsList = new IndexedWordItems();
+        Tag expectedTag = new Tag(new TagName(firstPartNameAsString + secondPartNameAsString), aParagraph, wordItemsList);
+
+        assertThat(tags.contains(expectedTag), equalTo(true));
     }
+
+    private Run createText(String text) {
+        Run runItemWithText = new Run();
+        runItemWithText.addText(new Text(text));
+        return runItemWithText;
+    }
+
+
+    private Paragraph createParagraphWithTag(String text) {
+        Paragraph paragraph = new Paragraph();
+        Run expectedItem = createText(text);
+        paragraph.addItem(expectedItem);
+        return paragraph;
+    }
+
 }


### PR DESCRIPTION
When a tag was separated in two parts like ${Begin_of_tag followed by
end_of_tag}, it was recognized but the underlying word items were not
properly stored.
So during the update process, when we try to replace those word items,
we had an exception.