### PR TITLE
Refactor TagTable to use TagTableValueRow and Cell instead of String

### DIFF
--- a/src/main/java/com/accelad/docx4j/facade/TableCell.java
+++ b/src/main/java/com/accelad/docx4j/facade/TableCell.java
@@ -1,5 +1,6 @@
 package com.accelad.docx4j.facade;
 
+import com.accelad.docx4j.tags.TagValueTableCell;
 import org.docx4j.jaxb.Context;
 import org.docx4j.wml.ObjectFactory;
 import org.docx4j.wml.Tc;
@@ -35,13 +36,18 @@ public class TableCell implements WordItem {
     }
 
     public static class TableCellBuilder {
-        private String text = "";
+        private String cellValue = "";
         private Integer width;
         private HorizontalMerge merge;
         private Alignment alignment;
 
-        public TableCellBuilder withText(String text) {
-            this.text = text;
+        public TableCellBuilder withText(String cellValue) {
+            this.cellValue = cellValue;
+            return this;
+        }
+
+        public TableCellBuilder withText(TagValueTableCell cell) {
+            this.cellValue = cell.toString();
             return this;
         }
 
@@ -65,7 +71,7 @@ public class TableCell implements WordItem {
             TableCell cell = new TableCell();
             Paragraph paragraph = new Paragraph();
             Run run = new Run();
-            run.addText(new Text(text));
+            run.addText(new Text(cellValue));
             paragraph.addItem(run);
             if (alignment != null) {
                 ParagraphProperties properties = new ParagraphProperties();

--- a/src/main/java/com/accelad/docx4j/tags/TagUpdaterTable.java
+++ b/src/main/java/com/accelad/docx4j/tags/TagUpdaterTable.java
@@ -1,18 +1,9 @@
 package com.accelad.docx4j.tags;
 
+import com.accelad.docx4j.facade.*;
 import org.apache.commons.lang3.StringUtils;
 
-import com.accelad.docx4j.facade.Alignment;
-import com.accelad.docx4j.facade.HorizontalMerge;
-import com.accelad.docx4j.facade.Paragraph;
-import com.accelad.docx4j.facade.Table;
-import com.accelad.docx4j.facade.TableBorders;
-import com.accelad.docx4j.facade.TableCell;
-import com.accelad.docx4j.facade.TableCellWidth;
-import com.accelad.docx4j.facade.TableGrid;
-import com.accelad.docx4j.facade.TableGridColumn;
-import com.accelad.docx4j.facade.TableProperties;
-import com.accelad.docx4j.facade.TableRow;
+import java.util.List;
 
 public class TagUpdaterTable implements TagValueUpdater {
     private final TagValueTable valueTable;
@@ -26,7 +17,7 @@ public class TagUpdaterTable implements TagValueUpdater {
     public boolean update(Tag tag) {
         Paragraph container = tag.getParagraph();
 
-        String[][] value = valueTable.getValue();
+        List<TagValueTableRow> value = valueTable.getRows();
 
         int columnCount = valueTable.getColumnCount();
 
@@ -40,9 +31,9 @@ public class TagUpdaterTable implements TagValueUpdater {
         int rowCount = valueTable.getRowCount();
         for (int i = 0; i < rowCount; i++) {
             TableRow row = new TableRow();
-            String[] rowValues = value[i];
+            TagValueTableRow rowValues = value.get(i);
 
-            for (String cellValue : rowValues) {
+            for (TagValueTableCell cellValue : rowValues) {
                 row.addCell(TableCell.builder()
                         .withText(cellValue)
                         .withAlignment(Alignment.CENTER)
@@ -60,10 +51,10 @@ public class TagUpdaterTable implements TagValueUpdater {
     }
 
 
-    private TableRow createHeaders(String[] headers) { // NOSONAR
+    private TableRow createHeaders(TagValueTableRow headers) {
         TableRow headerRow = new TableRow();
 
-        for (String header : headers) {
+        for (TagValueTableCell header : headers) {
             headerRow.addCell(TableCell.builder()
                     .withText(header)
                     .withAlignment(Alignment.CENTER)
@@ -93,12 +84,11 @@ public class TagUpdaterTable implements TagValueUpdater {
 
         TableHeaderGroup[] groups = valueTable.getHeaderGroups();
 
-        for (int g=0; g < groups.length; g++) {
-            TableHeaderGroup group = groups[g];
-
+        for (TableHeaderGroup group : groups) {
             TableCell.TableCellBuilder builder = TableCell.builder();
             if (!StringUtils.isEmpty(group.getTitle())) {
-                    builder.withText(group.getTitle()).withAlignment(Alignment.CENTER);
+                    builder.withText(group.getTitle())
+                            .withAlignment(Alignment.CENTER);
             }
             titleRow.addCell(builder.withMerge(HorizontalMerge.RESTART).build());
 

--- a/src/main/java/com/accelad/docx4j/tags/TagValueTable.java
+++ b/src/main/java/com/accelad/docx4j/tags/TagValueTable.java
@@ -1,43 +1,43 @@
 package com.accelad.docx4j.tags;
 
-import static java.util.Arrays.stream;
-import static java.util.stream.Collectors.joining;
-
 import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
 
 public class TagValueTable implements TagValue {
 
     private final String title;
-    private final String[] headers;
+    private final TagValueTableRow headers;
     private final TableHeaderGroup[] headerGroups;
-    private final String[][] tableValues;
+    private final List<TagValueTableRow> tableValues;
 
-    public TagValueTable(String title, String[] headers, String[][] tableValues) {
+    public TagValueTable(String title, TagValueTableRow headers, List<TagValueTableRow> tableValues) {
         this(title, headers, null, tableValues);
     }
 
-    public TagValueTable(String title, String[] headers, TableHeaderGroup[] headerGroups,
-            String[][] tableValues) {
+    public TagValueTable(String title, TagValueTableRow headers, TableHeaderGroup[] headerGroups,
+                         List<TagValueTableRow> tableValues) {
         this.headerGroups = headerGroups;
         this.tableValues = tableValues;
         this.title = title;
         this.headers = headers;
     }
 
-    public String[] getHeaders() {
+    public TagValueTableRow getHeaders() {
         return headers;
     }
 
-    public String[][] getValue() {
+    public List<TagValueTableRow> getRows() {
         return tableValues;
     }
 
     public int getColumnCount() {
-        return headers.length;
+        return headers.size();
     }
 
     public int getRowCount() {
-        return tableValues.length;
+        return tableValues.size();
     }
 
     public String getTitle() {
@@ -55,39 +55,27 @@ public class TagValueTable implements TagValue {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         TagValueTable that = (TagValueTable) o;
-
-        if (title != null ? !title.equals(that.title) : that.title != null)
-            return false;
-        if (!Arrays.equals(headers, that.headers))
-            return false;
-        if (!Arrays.equals(headerGroups, that.headerGroups))
-            return false;
-        return Arrays.deepEquals(tableValues, that.tableValues);
+        return Objects.equals(title, that.title) &&
+                Objects.equals(headers, that.headers) &&
+                Arrays.equals(headerGroups, that.headerGroups) &&
+                Objects.equals(tableValues, that.tableValues);
     }
 
     @Override
     public int hashCode() {
-        int result = title != null ? title.hashCode() : 0;
-        result = 31 * result + Arrays.hashCode(headers);
-        result = 31 * result + Arrays.hashCode(headerGroups);
-        result = 31 * result + Arrays.deepHashCode(tableValues);
-        return result;
+        return Objects.hash(title, headers, headerGroups, tableValues);
     }
 
     @Override
     public String toString() {
-        return "TagValueTable{" + "title='" + title + '\'' + ", headers=" + Arrays.toString(
-                headers) + ", headerGroups=" + Arrays.toString(
-                headerGroups) + ", tableValues=" + valuesToString() + '}';
-    }
-
-    private String valuesToString() {
-        return stream(tableValues).map(Arrays::toString).collect(joining(", "));
+        return "TagValueTable{" +
+                "title='" + title + '\'' +
+                ", headers=" + headers +
+                ", headerGroups=" + Arrays.toString(headerGroups) +
+                ", tableValues=" + tableValues +
+                '}';
     }
 }

--- a/src/main/java/com/accelad/docx4j/tags/TagValueTableCell.java
+++ b/src/main/java/com/accelad/docx4j/tags/TagValueTableCell.java
@@ -1,0 +1,29 @@
+package com.accelad.docx4j.tags;
+
+import java.util.Objects;
+
+public class TagValueTableCell {
+    private final String value;
+
+    public TagValueTableCell(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TagValueTableCell that = (TagValueTableCell) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+}

--- a/src/main/java/com/accelad/docx4j/tags/TagValueTableRow.java
+++ b/src/main/java/com/accelad/docx4j/tags/TagValueTableRow.java
@@ -1,0 +1,53 @@
+package com.accelad.docx4j.tags;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class TagValueTableRow implements Iterable<TagValueTableCell>{
+    private final List<TagValueTableCell> values;
+
+    public TagValueTableRow(){
+        this.values = new ArrayList<>();
+    }
+
+    public TagValueTableRow(String... values){
+        this.values = Arrays.stream(values).map(TagValueTableCell::new).collect(Collectors.toList());
+    }
+
+    public TagValueTableRow(TagValueTableCell... cells){
+        this.values = new ArrayList<>(Arrays.asList(cells));
+    }
+
+    public List<TagValueTableCell> getValues() {
+        return values;
+    }
+
+    public int size() {
+        return values.size();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TagValueTableRow that = (TagValueTableRow) o;
+        return Objects.equals(values, that.values);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(values);
+    }
+
+    @Override
+    public String toString() {
+        return "TagValueTableRow{" +
+                "values=" + values +
+                '}';
+    }
+
+    @Override
+    public Iterator<TagValueTableCell> iterator() {
+        return values.iterator();
+    }
+}

--- a/src/test/java/com/accelad/docx4j/UpdateTagInTableTest.java
+++ b/src/test/java/com/accelad/docx4j/UpdateTagInTableTest.java
@@ -4,7 +4,10 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
 
+import com.accelad.docx4j.tags.*;
 import org.apache.commons.io.IOUtils;
 import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
@@ -14,17 +17,6 @@ import org.junit.Test;
 import com.accelad.docx4j.facade.Paragraphs;
 import com.accelad.docx4j.facade.WordProcessor;
 import com.accelad.docx4j.facade.WordProcessorDocx4J;
-import com.accelad.docx4j.tags.ReportImage;
-import com.accelad.docx4j.tags.Tag;
-import com.accelad.docx4j.tags.TagName;
-import com.accelad.docx4j.tags.TagScanner;
-import com.accelad.docx4j.tags.TagUpdater;
-import com.accelad.docx4j.tags.TagUpdaterFactory;
-import com.accelad.docx4j.tags.TagValue;
-import com.accelad.docx4j.tags.TagValueImage;
-import com.accelad.docx4j.tags.TagValueString;
-import com.accelad.docx4j.tags.TagValueTable;
-import com.accelad.docx4j.tags.TagValues;
 
 public class UpdateTagInTableTest {
 
@@ -71,8 +63,9 @@ public class UpdateTagInTableTest {
 
     @Test
     public void should_update_tag_in_a_table_with_a_table() {
-        String[] headers = { "header1", "header2" };
-        String[][] values = { { "values11", "values12" }, { "values21", "values22" } };
+        TagValueTableRow headers = new TagValueTableRow("header1", "header2" );
+        List<TagValueTableRow> values = Arrays.asList( new TagValueTableRow( "values11", "values12" ),
+                new TagValueTableRow( "values21", "values22" ) );
         TagValue key = new TagValueTable("the title", headers, values);
         TagUpdater updater = getTagUpdaterForTagValue(wordprocessingMLPackageWithTable, key);
 

--- a/src/test/java/com/accelad/docx4j/tags/TagUpdaterBlockTest.java
+++ b/src/test/java/com/accelad/docx4j/tags/TagUpdaterBlockTest.java
@@ -1,5 +1,6 @@
 package com.accelad.docx4j.tags;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyInt;
@@ -12,6 +13,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 
 import org.apache.commons.io.IOUtils;
@@ -35,7 +37,9 @@ import com.accelad.docx4j.tags.TagValueTable;
 
 public class TagUpdaterBlockTest {
 
-    private static final TagValueTable TAG_VALUE_TABLE = new TagValueTable("Title", new String[] {"1", "2"}, new String[][] {{"1a", "2a"}});
+    private static final TagValueTable TAG_VALUE_TABLE = new TagValueTable("Title",
+            new TagValueTableRow("1", "2"),
+            singletonList(new TagValueTableRow("1a", "2a")));
     public static final TagValueString TAG_VALUE_STRING = new TagValueString("TEST");
     private static final TagValue[] TAG_VALUE_CONTENTS = new TagValue[] {TAG_VALUE_TABLE, TAG_VALUE_STRING};
     private static final TagValueBlock TAG_VALUE_BLOCK = new TagValueBlock(TAG_VALUE_CONTENTS);

--- a/src/test/java/com/accelad/docx4j/tags/TagUpdaterParagraphsTest.java
+++ b/src/test/java/com/accelad/docx4j/tags/TagUpdaterParagraphsTest.java
@@ -1,5 +1,6 @@
 package com.accelad.docx4j.tags;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyInt;
@@ -11,6 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import org.docx4j.wml.P;
@@ -31,7 +33,9 @@ import com.accelad.docx4j.tags.TagValueTable;
 
 public class TagUpdaterParagraphsTest {
 
-    private static final TagValueTable TAG_VALUE_TABLE = new TagValueTable("Title", new String[] {"1", "2"}, new String[][] {{"1a", "2a"}});
+    private static final TagValueTable TAG_VALUE_TABLE = new TagValueTable("Title",
+            new TagValueTableRow("1", "2"),
+            singletonList(new TagValueTableRow("1a", "2a")));
     public static final TagValueString TAG_VALUE_STRING = new TagValueString("TEST");
     private static final TagValue[] TAG_VALUE_CONTENTS = new TagValue[] {TAG_VALUE_TABLE, TAG_VALUE_STRING};
     private static final TagValueBlock TAG_VALUE = new TagValueBlock(TAG_VALUE_CONTENTS);

--- a/src/test/java/com/accelad/docx4j/tags/TagUpdaterTableTest.java
+++ b/src/test/java/com/accelad/docx4j/tags/TagUpdaterTableTest.java
@@ -14,9 +14,11 @@ import com.accelad.docx4j.facade.IndexedWordItems;
 import com.accelad.docx4j.facade.Paragraph;
 import com.accelad.docx4j.facade.Table;
 
+import java.util.Collections;
+
 public class TagUpdaterTableTest {
-    private static final TagValueTable TAG_VALUE = new TagValueTable("My title", new String[] {},
-            new String[][] {});
+    private static final TagValueTable TAG_VALUE = new TagValueTable("My title", new TagValueTableRow(),
+            Collections.emptyList());
 
     @Mock private Paragraph container;
     private IndexedWordItems itemsToReplace = new IndexedWordItems();

--- a/src/test/java/com/accelad/docx4j/tags/TagValueTableTest.java
+++ b/src/test/java/com/accelad/docx4j/tags/TagValueTableTest.java
@@ -4,17 +4,20 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class TagValueTableTest {
 
     @Test
     public void should_display_table_content_with_sub_arrays() {
-        String[] header = { "header1", "header2" };
-        String[][] values = { { "01", "02" }, { "A", "B" } };
+        TagValueTableRow header = new TagValueTableRow( "header1", "header2" );
+        List<TagValueTableRow> values = Arrays.asList(new TagValueTableRow( "01", "02" ), new TagValueTableRow( "A", "B" ));
 
         TagValueTable tagValueTable = new TagValueTable("title", header, values);
 
         assertEquals(
-                "TagValueTable{title='title', headers=[header1, header2], headerGroups=null, tableValues=[01, 02], [A, B]}",
+                "TagValueTable{title='title', headers=TagValueTableRow{values=[header1, header2]}, headerGroups=null, tableValues=[TagValueTableRow{values=[01, 02]}, TagValueTableRow{values=[A, B]}]}",
                 tagValueTable.toString());
 
     }


### PR DESCRIPTION
The TagTable will not use String type values (like String[][]).