### PR TITLE
Add merge possibility to WordProcessor

### DIFF
--- a/src/main/java/com/accelad/docx4j/facade/WordProcessor.java
+++ b/src/main/java/com/accelad/docx4j/facade/WordProcessor.java
@@ -25,4 +25,10 @@ public interface WordProcessor {
 
     void replaceBy(WordItemContainer container, WordItems items, WordItem item);
 
+    void clearBodyContent();
+
+    void mergeContentWith(WordProcessor processor);
+
+    List<Object> getContent();
+
 }

--- a/src/main/java/com/accelad/docx4j/facade/WordProcessorDocx4J.java
+++ b/src/main/java/com/accelad/docx4j/facade/WordProcessorDocx4J.java
@@ -140,7 +140,18 @@ public class WordProcessorDocx4J implements WordProcessor {
         container.addItem(item, position);
     }
 
-    private List<Object> getContent() {
+    @Override
+    public void clearBodyContent() {
+        wordprocessingMLPackage.getMainDocumentPart().getContent().clear();
+    }
+
+    @Override
+    public List<Object> getContent() {
         return wordprocessingMLPackage.getMainDocumentPart().getContent();
+    }
+
+    @Override
+    public void mergeContentWith(WordProcessor processor) {
+        wordprocessingMLPackage.getMainDocumentPart().getContent().addAll(processor.getContent());
     }
 }


### PR DESCRIPTION
When we want to concatenate multiple document into one we have to merge
their content. 
Now the Wordprocessor is able to take the content from one another processor and merge it in the actual one.

